### PR TITLE
FIX: FilterResource did not work on windows-platform as it used the File.separator instead of '/'

### DIFF
--- a/src/main/java/org/avaje/classpath/scanner/FilterResource.java
+++ b/src/main/java/org/avaje/classpath/scanner/FilterResource.java
@@ -43,8 +43,8 @@ public class FilterResource {
 
     @Override
     public boolean isMatch(String resourceName) {
-
-      String fileName = resourceName.substring(resourceName.lastIndexOf(File.separator) + 1);
+      // FIX: Use '/' instead of File.separator, as resources always use '/' as separator
+      String fileName = resourceName.substring(resourceName.lastIndexOf('/') + 1);
       return fileName.startsWith(prefix) && fileName.endsWith(suffix);
     }
   }


### PR DESCRIPTION
Theis leads to a test failure in the "avaje-classpath-scanner" (and I think it is wrong, to use the OS fileseparator, because there is an other place that explicitely changes all "\" to "/" for resource names)
